### PR TITLE
Department enum created

### DIFF
--- a/eventOrganizer/Department.java
+++ b/eventOrganizer/Department.java
@@ -1,4 +1,33 @@
 package eventOrganizer;
 
-public class Department {
+/**
+ * Enum class to represent all departments
+ * @author Michael Muzafarov
+ */
+public enum Department {
+    CS("computer science"),
+    EE("electrical engineering"),
+    ITI("information technology and informatics"),
+    MATH("mathematics"),
+    BAIT("business analytics and information technology")
+    ;
+
+    private final String fullName;
+
+    /**
+     * Only used internally to give each constant a name
+     * @param fullName entire name of constant
+     */
+    Department(String fullName) {
+        this.fullName = fullName;
+    }
+
+    /**
+     * turn constant into string representation
+     * @return string with full department name
+     */
+    @Override
+    public String toString() {
+        return fullName;
+    }
 }


### PR DESCRIPTION
Requirements:
-use the department acronyms for the constant names, or lose 3 points. 
-You can include a property to represent the full name or override the toString() method to produce the full name.
- Assume the event calendar only opens to five departments: CS (computer science), EE (electrical engineering), ITI (information technology and informatics), MATH (mathematics) and BAIT (business analytics and information technology).